### PR TITLE
Add puppet environment to agent info and add failed catalog metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,8 +20,7 @@ Usage:
 
 The commands & flags are:
 
-  version                   print the version to stdout
-`
+  version                   print the version to stdout`
 
 var (
 	version   = "n/a"

--- a/summary_report.go
+++ b/summary_report.go
@@ -23,7 +23,15 @@ func (r *summaryReportScraper) UnmarshalYAML(unmarshal func(interface{}) error) 
 	var v struct {
 		Version struct {
 			Puppet string
-			Config float64
+			Config string
+		}
+		Application struct {
+			RunMode              string `yaml:"run_mode"`
+			InitialEnvironment   string `yaml:"initial_environment"`
+			ConvergedEnvironment string `yaml:"converged_environment"`
+		}
+		Time struct {
+			LastRun float64 `yaml:"last_run"`
 		}
 	}
 	if err := unmarshal(&v); err != nil {
@@ -31,7 +39,10 @@ func (r *summaryReportScraper) UnmarshalYAML(unmarshal func(interface{}) error) 
 	}
 
 	r.reportScraper.setPuppetVersion(v.Version.Puppet)
-	r.reportScraper.setConfigTimestamp(v.Version.Config)
+	r.reportScraper.setConfigTimestamp(v.Time.LastRun)
+	r.setCatalogVersion(v.Version.Config)
+
+	r.setInfo("environment", v.Application.ConvergedEnvironment)
 
 	var objmap map[string]gaugeValueMap
 	unmarshal(&objmap)


### PR DESCRIPTION
Added metric:
`puppet_agent_catalog_failed` which will indicate if any catalog was downloaded and applied during the last run.

Also extended metric:
`puppet_agent_info`

With label `environment` containing info from which environment was this catalog applied.
